### PR TITLE
🐛 Fix container crashing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 .gitignore
 .gitattributes
 
+# Logs
+/logs
+*.log
+
 # Local env variables
 .env
 .env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY . .
 
+RUN mkdir logs
+
 RUN deno install --entrypoint main.ts
 
 ENTRYPOINT [ "deno", "run", "-A", "--unstable-cron", "main.ts" ]


### PR DESCRIPTION
LogTape can't create directories so we need to make sure this directory is made created in the container